### PR TITLE
chore: add downstream workflow calls manually

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,7 @@ on:
       - main
       - develop
   merge_group:
+  workflow_call:
 
 concurrency:
   group: (${{ github.workflow }}-${{ github.event.inputs.branch || github.event.pull_request.head.ref }})

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -6,6 +6,7 @@ on:
     - cron: "0 0 * * *"
   # on demand
   workflow_dispatch:
+  push:
 
 jobs:
   auto-update:

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -35,11 +35,12 @@ jobs:
           branch: update/pre-commit-hooks
           title: Update pre-commit hooks
           commit-message: "chore: update pre-commit hooks"
-          body: Update versions of pre-commit hooks to latest version.
+          body:
+            Update versions of pre-commit hooks to latest version.
             # output is called pull-request-operation
       - name: Set outputs
         id: check-diff
-        if: | 
+        if: |
           steps.pr-create.outputs.pull-request-number &&
           (steps.pr-create.outputs.pull-request-operation == 'created' ||
           steps.pr-create.outputs.pull-request-operation == 'updated')
@@ -47,15 +48,12 @@ jobs:
 
   lint-workflow:
     name: Run lint
-    uses: ./.github/workflows/lint.yml
-    if: ${{ needs.auto-update.outputs.diff }}
-    runs-on: ubuntu-latest
     needs: auto-update
-
+    if: ${{ needs.auto-update.outputs.diff }}
+    uses: ./.github/workflows/lint.yml
 
   test-workflow:
     name: run tests on diff
-    uses: ./.github/workflows/test.yml
-    if: ${{ needs.auto-update.outputs.diff }}
-    runs-on: ubuntu-latest
     needs: auto-update
+    if: ${{ needs.auto-update.outputs.diff }}
+    uses: ./.github/workflows/test.yml

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -14,6 +14,17 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
       - uses: browniebroke/pre-commit-autoupdate-action@main
+      - name: Check for changes
+        id: git-check
+        run: |
+          git diff --exit-code || echo "::set-output name=modified::true"
+        continue-on-error: true
+      - name: lint on diff
+        if: steps.git-check.outputs.modified == 'true'
+        uses: ./github/workflows/lint.yml
+      - name: run tests on diff
+        if: steps.git-check.outputs.modified == 'true'
+        uses: ./github/workflows/test.yml
       - uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -22,10 +22,10 @@ jobs:
         continue-on-error: true
       - name: lint on diff
         if: steps.git-check.outputs.modified == 'true'
-        uses: ./github/workflows/lint.yml
+        uses: ./.github/workflows/lint.yml
       - name: run tests on diff
         if: steps.git-check.outputs.modified == 'true'
-        uses: ./github/workflows/test.yml
+        uses: ./.github/workflows/test.yml
       - uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -17,17 +17,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
       - uses: browniebroke/pre-commit-autoupdate-action@main
-      # - name: Check for changes
-      #   id: git-check
-      #   run: |
-      #     git diff --exit-code || echo "::set-output name=modified::true"
-      #   continue-on-error: true
-      # - name: lint on diff
-      #   if: steps.git-check.outputs.modified == 'true'
-      #   uses: ./.github/workflows/lint.yml
-      # - name: run tests on diff
-      #   if: steps.git-check.outputs.modified == 'true'
-      #   uses: ./.github/workflows/test.yml
       - uses: peter-evans/create-pull-request@v6
         id: pr-create
         with:
@@ -37,14 +26,17 @@ jobs:
           commit-message: "chore: update pre-commit hooks"
           body:
             Update versions of pre-commit hooks to latest version.
-            # output is called pull-request-operation
       - name: Set outputs
         id: check-diff
         if: |
-          steps.pr-create.outputs.pull-request-number &&
           (steps.pr-create.outputs.pull-request-operation == 'created' ||
-          steps.pr-create.outputs.pull-request-operation == 'updated')
-        run: echo "diff=true" >> "$GITHUB_OUTPUT"
+          steps.pr-create.outputs.pull-request-operation == 'updated') &&
+          steps.pr-create.outputs.pull-request-number
+        run: |
+          echo "diff=true" >> "$GITHUB_OUTPUT"
+          echo "PR status: ${{ steps.pr-create.outputs.pull-request-operation }}"
+          echo "PR number: ${{ steps.pr-create.outputs.pull-request-number }}"
+          echo "Running workflows for ${{ steps.pr-create.outputs.pull-request-url }}"
 
   lint-workflow:
     name: Run lint

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 0 * * *"
   # on demand
   workflow_dispatch:
-  push:
 
 jobs:
   auto-update:
@@ -24,8 +23,7 @@ jobs:
           branch: update/pre-commit-hooks
           title: Update pre-commit hooks
           commit-message: "chore: update pre-commit hooks"
-          body:
-            Update versions of pre-commit hooks to latest version.
+          body: Update versions of pre-commit hooks to latest version.
       - name: Set outputs
         id: check-diff
         if: |

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -11,25 +11,51 @@ on:
 jobs:
   auto-update:
     runs-on: ubuntu-latest
+    outputs:
+      diff: ${{ steps.check-diff.outputs.diff }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
       - uses: browniebroke/pre-commit-autoupdate-action@main
-      - name: Check for changes
-        id: git-check
-        run: |
-          git diff --exit-code || echo "::set-output name=modified::true"
-        continue-on-error: true
-      - name: lint on diff
-        if: steps.git-check.outputs.modified == 'true'
-        uses: ./.github/workflows/lint.yml
-      - name: run tests on diff
-        if: steps.git-check.outputs.modified == 'true'
-        uses: ./.github/workflows/test.yml
+      # - name: Check for changes
+      #   id: git-check
+      #   run: |
+      #     git diff --exit-code || echo "::set-output name=modified::true"
+      #   continue-on-error: true
+      # - name: lint on diff
+      #   if: steps.git-check.outputs.modified == 'true'
+      #   uses: ./.github/workflows/lint.yml
+      # - name: run tests on diff
+      #   if: steps.git-check.outputs.modified == 'true'
+      #   uses: ./.github/workflows/test.yml
       - uses: peter-evans/create-pull-request@v6
+        id: pr-create
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: update/pre-commit-hooks
           title: Update pre-commit hooks
           commit-message: "chore: update pre-commit hooks"
           body: Update versions of pre-commit hooks to latest version.
+            # output is called pull-request-operation
+      - name: Set outputs
+        id: check-diff
+        if: | 
+          steps.pr-create.outputs.pull-request-number &&
+          (steps.pr-create.outputs.pull-request-operation == 'created' ||
+          steps.pr-create.outputs.pull-request-operation == 'updated')
+        run: echo "diff=true" >> "$GITHUB_OUTPUT"
+
+  lint-workflow:
+    name: Run lint
+    uses: ./.github/workflows/lint.yml
+    if: ${{ needs.auto-update.outputs.diff }}
+    runs-on: ubuntu-latest
+    needs: auto-update
+
+
+  test-workflow:
+    name: run tests on diff
+    uses: ./.github/workflows/test.yml
+    if: ${{ needs.auto-update.outputs.diff }}
+    runs-on: ubuntu-latest
+    needs: auto-update

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ on:
       - develop
       - "[0-9]+.[0-9]+.x"
   merge_group:
+  workflow_call:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Overview
Pulls in additional GH workflows *if* there's a dep update on `pre-commit update`. 

## Description

This allows for other GH workflows to run in-line without additional effort or config.

### PROS
- No extra config needed

### CONS
- potentially not the easiest-identifiable sequence of runs

With that said, the *actual workflows* that would be run on any other mergeable PR do get run here. 

